### PR TITLE
ignore asccimath

### DIFF
--- a/mikidown/config.py
+++ b/mikidown/config.py
@@ -70,7 +70,7 @@ class Setting():
                  , 'headerid'        # add id to headers
                  , 'headerlink'      # add anchor to headers
                  , 'footnotes'
-                 , 'mdx_asciimathml'
+                 #, 'mdx_asciimathml'
                  ]
             writeListToSettings(self.qsettings, "extensions", self.extensions)
 


### PR DESCRIPTION
https://github.com/favalex/python-asciimathml says it is for python 2.7, and mikidown needs python +3.0

I cannot install asciimath on python 3 (a problem with cpython compilation), so how do you get this to work?

By now I commented asciimath
