### PR TITLE
A better regex for parsing headers

### DIFF
--- a/mikidown/utils.py
+++ b/mikidown/utils.py
@@ -108,7 +108,8 @@ def parseHeaders(source):
     used_ids = set()           # In case there are headers with the same name.
 
     # hash headers
-    RE = re.compile(r'^(#+)(.+)', re.MULTILINE)
+    #RE = re.compile(r'^(#+)(.+)', re.MULTILINE)
+    RE = re.compile(r'(?:(?<!```\s)^(\S+#+ )(.+)$(?!\s```))', re.MULTILINE)
     for m in RE.finditer(source):
         level = len(m.group(1))
         hdr = m.group(2)


### PR DESCRIPTION
Not so sexy mainly because of my lacks of knowledge, plus this [shitty limitation](http://stackoverflow.com/questions/9030305/regular-expression-lookbehind-doesnt-work-with-quantifiers-or)...
But at least now you can write fenced codes blocks without polluting your Table of contents!

Note: headers must now contain a space after the `#` char(s).. because all examples in Markdown documentation use this syntax, but it's trivial to reverse.